### PR TITLE
修复自定义组件在懒加载界面无法显示的Bug

### DIFF
--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -1,8 +1,8 @@
 import { IonicModule } from 'ionic-angular';
 import { NgModule } from '@angular/core';
-
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 // 解决ngFor报错
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 
 
 import { PaymentComponent } from './payment/payment';
@@ -14,8 +14,8 @@ import { FundinfoComponent } from './fundinfo/fundinfo';
         PaymentComponent
     ],
     imports: [
-        IonicModule,
-        BrowserModule
+      //  IonicModule, 假如你的自定义组件中包含表单元素，还需要引入  FormsModule, ReactiveFormsModule,
+        CommonModule
     ],
     exports: [
         FundinfoComponent,

--- a/src/pages/payment-approval/payment-approval.html
+++ b/src/pages/payment-approval/payment-approval.html
@@ -46,5 +46,5 @@
     <button ion-button class="danger">驳回</button>
   </div>
 
-
+ <payment></payment>
 </ion-content>

--- a/src/pages/payment-approval/payment-approval.module.ts
+++ b/src/pages/payment-approval/payment-approval.module.ts
@@ -1,25 +1,18 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 import { PaymentApprovalPage } from './payment-approval';
-
-
 //  components模块 组件
-// import { ComponentsModule } from '../../components/components.module';
+import { ComponentsModule } from '../../components/components.module';
 
 @NgModule({
   declarations: [
     PaymentApprovalPage
   ],
   imports: [
-    // ComponentsModule,
+    ComponentsModule,
     IonicPageModule.forChild(PaymentApprovalPage),
   ],
   exports: [
-    PaymentApprovalPage,
-
   ]
-  // ,entryComponents: [
-  //   PaymentApprovalPage
-  // ]
 })
 export class PaymentApprovalPageModule { }


### PR DESCRIPTION
这个问题的根源还是你没有明白一件事情，你的ComponentModule，单独在APPModule中导入是不可以的，需要在使用到它的每个Module中导入。这个与provider不一样，它在APPModule导入一遍之后到处可用。PaymentApprovalPageModule是一个单独的Module，所以还需要再导入一次。